### PR TITLE
Fix handling of very small floating point numbers

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -19,7 +19,7 @@ describe('safeParseFloat', function () {
     expect(safeParseFloat('Infinity')).to.eq(Infinity);
     expect(safeParseFloat('+Infinity')).to.eq(+Infinity);
     expect(safeParseFloat('-Infinity')).to.eq(-Infinity);
-    expect(() => safeParseFloat('0.000000000001')).to.throw(TypeError);
+    expect(safeParseFloat('0.000000000001')).to.eq(0.000000000001);
     expect(safeParseFloat('3.45')).to.eq(3.45);
     expect(safeParseFloat('0.050')).to.eq(0.05);
     expect(safeParseFloat('0.550')).to.eq(0.55);

--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,13 @@ export function floatTrim(text) {
  * @return {Boolean} True if the parsed number is the same as precision text representation.
  */
 export function floatCompare(parsed, text) {
-  let precision = (text.match(/[0-9]/g) || []).length;
-  return floatTrim(parsed.toPrecision(precision)) === floatTrim(text);
+  let precision = 0;
+  const decimalIndex = text.indexOf('.');
+  if (decimalIndex !== -1) {
+    precision = (text.substring(decimalIndex + 1).match(/[0-9]/g) || []).length;
+  }
+  return floatTrim(parsed.toFixed(precision)) === floatTrim(text);
+
 }
 
 /**


### PR DESCRIPTION
Previously, if a number that was being checked was very small (i.e., had significant figures after many decimal places), JavaScript would automatically convert its output to scientific notation. However, `floatCompare()` was not handling this possibility properly, leading to false positives of unsafe floats. This commit fixes this issue.

Fixes: #1